### PR TITLE
Daytona USA - All regions sector_delay fix

### DIFF
--- a/doc/saroocfg.txt
+++ b/doc/saroocfg.txt
@@ -128,3 +128,9 @@ sector_delay=500
 # Fixes advanced and export routes booting to system
 [GS-9013   V1.000]
 sector_delay=500
+
+
+# LAST GLADIATORS
+# Fixes black screen when leaving options
+[T-4804H   V1.000]
+sector_delay=1000

--- a/doc/saroocfg.txt
+++ b/doc/saroocfg.txt
@@ -110,3 +110,21 @@ sector_delay=1000
 [T-8118G   V1.000]
 play_delay = 100000
 sector_delay = 4200
+
+
+# DAYTONA USA (E)
+# Fixes advanced and export routes booting to system
+[MK_8120050V1.000]
+sector_delay=500
+
+
+# DAYTONA USA (U)
+# Fixes advanced and export routes booting to system
+[MK-81200  V1.000]
+sector_delay=500
+
+
+# DAYTONA USA (J)
+# Fixes advanced and export routes booting to system
+[GS-9013   V1.000]
+sector_delay=500


### PR DESCRIPTION
## Problem

On all regions, the game will boot to the system disc screen when you access the `Advanced` and `Expert` routes.

## Solution

Add `sector_delay` parameter to all regions of this game.

## Evidence

[![[Sample] SAROO 1.32 (231125) - Daytona USA (U) = Fixed?](https://img.youtube.com/vi/YZOGw2jjz5k/0.jpg)](https://youtu.be/YZOGw2jjz5k)
