### PR TITLE
Add support for .BUP save format (import/export) to savetool

### DIFF
--- a/tools/savetool/bup.h
+++ b/tools/savetool/bup.h
@@ -39,21 +39,21 @@ void bup_flush(void);
 
 int sr_bup_init(u8 *buf);
 int sr_bup_list(int slot_id);
-int sr_bup_export(int slot_id, int save_id);
+int sr_bup_export(int slot_id, int save_id, int exp_type);
 int sr_bup_import(int slot_id, int save_id, char *save_name);
 int sr_bup_delete(int slot_id, int save_id);
 int sr_bup_create(char *game_id);
 
 int ss_bup_init(u8 *buf);
 int ss_bup_list(int slot_id);
-int ss_bup_export(int slot_id, int save_id);
+int ss_bup_export(int slot_id, int save_id, int exp_type);
 int ss_bup_import(int slot_id, int save_id, char *save_name);
 int ss_bup_delete(int slot_id, int save_id);
 int ss_bup_create(char *game_id);
 
 int sr_mems_init(u8 *buf);
 int sr_mems_list(int slot_id);
-int sr_mems_export(int slot_id, int save_id);
+int sr_mems_export(int slot_id, int save_id, int exp_type);
 int sr_mems_import(int slot_id, int save_id, char *save_name);
 int sr_mems_delete(int slot_id, int save_id);
 int sr_mems_create(char *game_id);

--- a/tools/savetool/bup_format.h
+++ b/tools/savetool/bup_format.h
@@ -1,0 +1,133 @@
+/*
+ * bup_header.h - structure definition for the .BUP file header used
+ * by various Sega Saturn tools.
+ *
+ * Format developed by Cafe-Alpha (https://segaxtreme.net/threads/save-game-metadata-questions.24625/post-178534)
+ *
+ */
+
+/** .BUP extension is required to work wih PS Kai */
+#define BUP_EXTENSION ".BUP"
+
+/** The BUP header structure (sizeof(vmem_bup_header_t)) is exactly 64 bytes */
+#define BUP_HEADER_SIZE 64
+
+/** BUP header magic */
+#define VMEM_MAGIC_STRING_LEN 4
+#define VMEM_MAGIC_STRING "Vmem"
+
+/** Max backup filename length */
+#define JO_BACKUP_MAX_FILENAME_LENGTH      (12)
+
+/** Max backup file comment length */
+#define JO_BACKUP_MAX_COMMENT_LENGTH       (10)
+
+/*
+ * Language of backup save in jo_backup_file
+ * taken from Jo Engine backup.c
+ */
+enum jo_backup_language
+{
+    backup_japanese = 0,
+    backup_english = 1,
+    backup_french = 2,
+    backup_deutsch = 3,
+    backup_espanol = 4,
+    backup_italiano = 5,
+};
+
+/**
+ * Backup file metadata information. Taken from Jo Engine.
+ **/
+typedef struct _jo_backup_file
+{
+    unsigned char filename[JO_BACKUP_MAX_FILENAME_LENGTH];
+    unsigned char comment[JO_BACKUP_MAX_COMMENT_LENGTH + 1];
+    unsigned char language; // jo_backup_language
+    unsigned int date;
+    unsigned int datasize;
+    unsigned short blocksize;
+    unsigned short padding;
+} jo_backup_file;
+
+typedef struct _jo_backup_date {
+    unsigned char year;       // year - 1980
+    unsigned char month;
+    unsigned char day;
+    unsigned char time;
+    unsigned char min;
+    unsigned char week;
+} jo_backup_date;
+
+#if defined( __GNUC__ )
+#pragma pack(1)
+#else
+#pragma pack(push,1)
+#endif
+
+/**
+ * Vmem usage statistics structure.
+ * Statistics are reset on each vmem session, ie when Saturn is reset,
+ * or when game calls BUP_Init function.
+ **/
+typedef struct _vmem_bup_stats_t
+{
+    /* Number of times BUP_Dir function is called. */
+    unsigned char dir_cnt;
+
+    /* Number of times BUP_Read function is called. */
+    unsigned char read_cnt;
+
+    /* Number of times BUP_Write function is called. */
+    unsigned char write_cnt;
+
+    /* Number of times BUP_Verify function is called. */
+    unsigned char verify_cnt;
+} vmem_bup_stats_t;
+
+
+/**
+ * Backup data header. Multibyte values are stored as big-endian.
+ **/
+typedef struct _vmem_bup_header_t
+{
+    /* Magic string.
+     * Used in order to verify that file is in vmem format.
+     */
+    char magic[VMEM_MAGIC_STRING_LEN];
+
+    /* Save ID.
+     * "Unique" ID for each save data file, the higher, the most recent.
+     */
+    unsigned int save_id;
+
+    /* Vmem usage statistics. */
+    vmem_bup_stats_t stats;
+
+    /* Unused, kept for future use. */
+    char unused1[8 - sizeof(vmem_bup_stats_t)];
+
+    /* Backup Data Informations Record (34 bytes + 2 padding bytes). */
+    jo_backup_file dir;
+
+    /* Date stamp, in Saturn's BUP library format.
+     * Used in order to verify which save data is the most
+     * recent one when rebuilding index data.
+     * Note #1 : this information is already present in BupDir structure,
+     * but games are setting it, so it may be incorrect (typically, set
+     * to zero).
+     * Note #2 : this date information is the date when Pseudo Saturn Kai
+     * last started, not the time the save was saved, so if information in
+     * dir structure is available, it is more accurate.
+     */
+    unsigned int date;
+
+    /* Unused, kept for future use. */
+    char unused2[8];
+} vmem_bup_header_t;
+
+#if defined( __GNUC__ )
+#pragma pack()
+#else
+#pragma pack(pop)
+#endif

--- a/tools/savetool/bup_format.h
+++ b/tools/savetool/bup_format.h
@@ -22,20 +22,6 @@
 /** Max backup file comment length */
 #define JO_BACKUP_MAX_COMMENT_LENGTH       (10)
 
-/*
- * Language of backup save in jo_backup_file
- * taken from Jo Engine backup.c
- */
-enum jo_backup_language
-{
-    backup_japanese = 0,
-    backup_english = 1,
-    backup_french = 2,
-    backup_deutsch = 3,
-    backup_espanol = 4,
-    backup_italiano = 5,
-};
-
 /**
  * Backup file metadata information. Taken from Jo Engine.
  **/

--- a/tools/savetool/sr_bup.c
+++ b/tools/savetool/sr_bup.c
@@ -3,6 +3,7 @@
 #include "stdlib.h"
 #include "string.h"
 #include "bup.h"
+#include "bup_format.h"
 
 
 /******************************************************************************/
@@ -179,7 +180,7 @@ static int sr_bup_select(int slot_id)
 /******************************************************************************/
 
 
-int sr_bup_export(int slot_id, int save_id)
+int sr_bup_export(int slot_id, int save_id, int exp_type)
 {
 	int block, i;
 	u8 *bp;
@@ -205,7 +206,24 @@ int sr_bup_export(int slot_id, int save_id)
 
 			char fname[16];
 			int fsize = get_be32(save_buf+0x1c);
-			sprintf(fname, "%s.bin", save_buf+0x10);
+			sprintf(fname, "%s%s", save_buf+0x10, exp_type ? BUP_EXTENSION : ".bin");
+
+			// if Export format is .BUP, add new header
+			if (exp_type==1)
+			{
+				vmem_bup_header_t bup_header = {0};
+				
+				memcpy(bup_header.magic, VMEM_MAGIC_STRING, VMEM_MAGIC_STRING_LEN);
+				memcpy(bup_header.dir.filename, bp, 11);
+				memcpy(bup_header.dir.comment, bp+0x10, 10);
+				memcpy(&bup_header.dir.date, bp+0x1c, 4);
+				memcpy(&bup_header.dir.datasize, bp+0x0c, 4);
+				memcpy(&bup_header.date, bp+0x1c, 4);
+				bup_header.dir.language = bp[0x1b];
+
+				memcpy(save_buf, &bup_header, BUP_HEADER_SIZE);
+			}
+
 			write_file(fname, save_buf, fsize+0x40);
 
 			printf("Export Save_%d: %s\n", i, fname);

--- a/tools/savetool/sr_bup.c
+++ b/tools/savetool/sr_bup.c
@@ -208,9 +208,8 @@ int sr_bup_export(int slot_id, int save_id, int exp_type)
 			int fsize = get_be32(save_buf+0x1c);
 			sprintf(fname, "%s%s", save_buf+0x10, exp_type ? BUP_EXTENSION : ".bin");
 
-			// if Export format is .BUP, add new header
-			if (exp_type==1)
-			{
+			// if Export format is .BUP, set new header
+			if (exp_type==1){
 				vmem_bup_header_t bup_header = {0};
 				
 				memcpy(bup_header.magic, VMEM_MAGIC_STRING, VMEM_MAGIC_STRING_LEN);

--- a/tools/savetool/sr_mems.c
+++ b/tools/savetool/sr_mems.c
@@ -3,6 +3,7 @@
 #include "stdlib.h"
 #include "string.h"
 #include "bup.h"
+#include "bup_format.h"
 
 
 /******************************************************************************/
@@ -94,7 +95,7 @@ static int access_data(int block, u8 *data, int type)
 /******************************************************************************/
 
 
-int sr_mems_export(int slot_id, int save_id)
+int sr_mems_export(int slot_id, int save_id, int exp_type)
 {
 	int block, i, index;
 	u8 *bp;
@@ -121,7 +122,24 @@ int sr_mems_export(int slot_id, int save_id)
 
 			char fname[16];
 			int fsize = get_be32(save_buf+0x1c);
-			sprintf(fname, "%s.bin", save_buf+0x10);
+			sprintf(fname, "%s%s", save_buf+0x10, exp_type ? BUP_EXTENSION : ".bin");
+
+			// if Export format is .BUP, add new header
+			if (exp_type==1)
+			{
+				vmem_bup_header_t bup_header = {0};
+				
+				memcpy(bup_header.magic, VMEM_MAGIC_STRING, VMEM_MAGIC_STRING_LEN);
+				memcpy(bup_header.dir.filename, bp, 11);
+				memcpy(bup_header.dir.comment, bp+0x10, 10);
+				memcpy(&bup_header.dir.date, bp+0x1c, 4);
+				memcpy(&bup_header.dir.datasize, bp+0x0c, 4);
+				memcpy(&bup_header.date, bp+0x1c, 4);
+				bup_header.dir.language = bp[0x1b];
+
+				memcpy(save_buf, &bup_header, BUP_HEADER_SIZE);
+			}
+
 			write_file(fname, save_buf, fsize+0x40);
 
 			printf("Export Save_%d: %s\n", index, fname);

--- a/tools/savetool/sr_mems.c
+++ b/tools/savetool/sr_mems.c
@@ -124,9 +124,8 @@ int sr_mems_export(int slot_id, int save_id, int exp_type)
 			int fsize = get_be32(save_buf+0x1c);
 			sprintf(fname, "%s%s", save_buf+0x10, exp_type ? BUP_EXTENSION : ".bin");
 
-			// if Export format is .BUP, add new header
-			if (exp_type==1)
-			{
+			// if Export format is .BUP, set new header
+			if (exp_type==1){
 				vmem_bup_header_t bup_header = {0};
 				
 				memcpy(bup_header.magic, VMEM_MAGIC_STRING, VMEM_MAGIC_STRING_LEN);

--- a/tools/savetool/ss_bup.c
+++ b/tools/savetool/ss_bup.c
@@ -163,9 +163,8 @@ int ss_bup_export(int slot_id, int index, int exp_type)
 				int fsize = get_be32(save_buf+0x1c);
 				sprintf(fname, "%s%s", save_buf+0x10, exp_type ? BUP_EXTENSION : ".bin");
 
-				// if Export format is .BUP, add new header
-				if (exp_type==1)
-				{
+				// if Export format is .BUP, set new header
+				if (exp_type==1){
 					vmem_bup_header_t bup_header = {0};
 					
 					memcpy(bup_header.magic, VMEM_MAGIC_STRING, VMEM_MAGIC_STRING_LEN);


### PR DESCRIPTION
Hello,

Currently the `savetool` utility to manage SAROO saves can import and export single Saturn saves using the `SSAVERAW` format.

I'm adding support for the `.BUP` save format (format created by the author of Pseudo Saturn Kai), as I think it can be very useful to import and export saves easily, and share them with other users that might not have Saroo but could have Saturn Kai. (Also .BUP is supported by other saturn tools and converters)

I tried to keep changes to the minimum, and follow the current application flow.

Changes:
- Import option (`-i`) can now detect `SSAVERAW` and `Vmem` as supported save formats.
- Added Export option (`-x`) that writes the selected saturn save using the ".BUP" format. Has the same behavior as `-s`, it only changes the output file format.

 If you have any questions or comments about this PR I'll be happy to answer

Thanks for your awesome work with Saroo! 