### PR TITLE
Saroo single save improvements

### DIFF
--- a/tools/savetool/bup.h
+++ b/tools/savetool/bup.h
@@ -33,6 +33,8 @@ u32 get_be16(void *p);
 void put_be32(void *p, u32 v);
 void put_be16(void *p, u32 v);
 
+u32 crc32b(u8 *data, int size);
+
 void set_bitmap(u8 *bmp, int index, int val);
 SAVEINFO *load_saveraw(char *save_name);
 void bup_flush(void);

--- a/tools/savetool/sr_bup.c
+++ b/tools/savetool/sr_bup.c
@@ -206,7 +206,8 @@ int sr_bup_export(int slot_id, int save_id, int exp_type)
 
 			char fname[16];
 			int fsize = get_be32(save_buf+0x1c);
-			sprintf(fname, "%s%s", save_buf+0x10, exp_type ? BUP_EXTENSION : ".bin");
+			put_be32(save_buf+0x0c, crc32b(save_buf+0x10, fsize+0x30));
+			sprintf(fname, "%s%s", save_buf+0x10, exp_type ? BUP_EXTENSION : ".SRO");
 
 			// if Export format is .BUP, set new header
 			if (exp_type==1){

--- a/tools/savetool/sr_mems.c
+++ b/tools/savetool/sr_mems.c
@@ -122,7 +122,8 @@ int sr_mems_export(int slot_id, int save_id, int exp_type)
 
 			char fname[16];
 			int fsize = get_be32(save_buf+0x1c);
-			sprintf(fname, "%s%s", save_buf+0x10, exp_type ? BUP_EXTENSION : ".bin");
+			put_be32(save_buf+0x0c, crc32b(save_buf+0x10, fsize+0x30));
+			sprintf(fname, "%s%s", save_buf+0x10, exp_type ? BUP_EXTENSION : ".SRO");
 
 			// if Export format is .BUP, set new header
 			if (exp_type==1){

--- a/tools/savetool/ss_bup.c
+++ b/tools/savetool/ss_bup.c
@@ -161,7 +161,8 @@ int ss_bup_export(int slot_id, int index, int exp_type)
 
 				char fname[16];
 				int fsize = get_be32(save_buf+0x1c);
-				sprintf(fname, "%s%s", save_buf+0x10, exp_type ? BUP_EXTENSION : ".bin");
+				put_be32(save_buf+0x0c, crc32b(save_buf+0x10, fsize+0x30));
+				sprintf(fname, "%s%s", save_buf+0x10, exp_type ? BUP_EXTENSION : ".SRO");
 
 				// if Export format is .BUP, set new header
 				if (exp_type==1){


### PR DESCRIPTION
Hello, following discussed topic in #270 
 
Improvements to SAROO single save format for save-game sharing
- add crc32 checksum at offset `0x0C`
- use `.SRO` file extension for Saroo single saves
- check crc32 when loading a Saroo single save
