### PR TITLE
Fix savetool sr_mems.c overwrite bug

### DIFF
--- a/tools/savetool/sr_mems.c
+++ b/tools/savetool/sr_mems.c
@@ -179,6 +179,7 @@ int sr_mems_import(int slot_id, int save_id, char *save_name)
 
 	if(block){
 		// overwrite
+		u8 *sbp;
 		char sname[20];
 		if(save_name==NULL){
 			sprintf(sname, "%s.bin", bp);
@@ -188,7 +189,10 @@ int sr_mems_import(int slot_id, int save_id, char *save_name)
 		if(save==NULL)
 			return -1;
 
-		*(u32*)(bp+0x1c) = save->date;
+		// bp points to the 16-byte directory entry, not the save block.
+		// The date lives in the save's start block, so update it there.
+		sbp = get_block_addr(block);
+		*(u32*)(sbp+0x1c) = save->date;
 		access_data(block, save->dbuf, 2);
 		printf("Import %s from %s.\n", bp, save_name);
 		return 0;


### PR DESCRIPTION
Hello @tpunix 👋  
I found an issue in the savetool source code in `sr_mems.c`: `bp` points to the 16-byte directory entry (`mems_buf+1024+i*16`), but `*(u32*)(bp+0x1c)` writes 28 bytes in — past the entry, into the next entry's block pointer. The date should be written to the save's start block (`get_block_addr(block)+0x1c`). 



 **Bug:** In `sr_mems_import()`'s overwrite branch, `bp` points at the 16-byte **directory entry**, but the date is written with `*(u32*)(bp+0x1c)`. Offset `0x1c` is 28 bytes into a 16-byte entry, so it lands at `directory_entry[i+1] + 0x0c` and overwrites the **next** save's start-block pointer (at `+0x0e`).

 **Impact:** 
- the overwritten save's date isn't actually updated (the real field is at `start_block + 0x1c`), and 
- the following save's directory entry is corrupted — it points at a garbage block and is lost. 

 **Fix:** resolve the start block first (`get_block_addr(block)`) and write the date there — exactly as the "new save" branch in the same function already does.
 