### PR TITLE
Fix out-of-bounds language hash table access

### DIFF
--- a/Firm_Saturn/language.c
+++ b/Firm_Saturn/language.c
@@ -401,7 +401,7 @@ char *TT(char *str)
 		return str;
 
 	u32 hash = str_hash(str);
-	STR_ENTRY *entry = lang_str_table[hash&0xff];
+	STR_ENTRY *entry = lang_str_table[hash&0x3f];
 	while(entry){
 		if(hash==entry->hash){
 			//printk("TT: %s(%08x) -> %d %s\n", str, hash, entry->index, lang_cur[entry->index]);
@@ -428,7 +428,7 @@ void lang_init(void)
 		lang_str[i].hash = str_hash(lang_zhcn[i]);
 		lang_str[i].index = i;
 
-		int t = (lang_str[i].hash)&0xff;
+		int t = (lang_str[i].hash)&0x3f;
 		if(lang_str_table[t]){
 			lang_str[i].next = lang_str_table[t];
 		}


### PR DESCRIPTION
## Summary

Fixes an out-of-bounds access in the language translation hash table that can cause the SAROO menu to freeze when switching languages with the L button.

## Problem

`lang_str_table` contains 64 entries:

```c
static STR_ENTRY *lang_str_table[64];
```

However, both the lookup and insertion code use an 8-bit mask:

```c
hash & 0xff
```

This produces indices from 0-255, while the valid range for `lang_str_table` is only 0-63.

This can access memory outside the hash table when translating menu strings after changing languages.

## Fix

Change both hash-table indexes to use:

```c
hash & 0x3f
```

This restricts the index to 0-63, matching the 64-entry table.

## Testing

Tested on real Sega Saturn hardware with SAROO.

Before this change:

- Pressing L on the main SAROO menu to change language caused the UI to freeze.

After this change:

- L changes languages successfully.
- The menu redraws correctly.
- The UI remains responsive.
- Repeated language changes work correctly.

The issue was also reproduced with a controller connected directly to Saturn controller port 1, so it is unrelated to the separate multitap modification I was testing.