### PR TITLE
Add OEM Japanese Sega 6-player multitap menu support

### DIFF
--- a/Firm_Saturn/main.c
+++ b/Firm_Saturn/main.c
@@ -93,6 +93,13 @@ int pad_read(void)
 			bits = (oreg[p+4]<<8) | (oreg[p+6]);
 			bits ^= 0xFFFF;
 			p += (oreg[p+2]&0x0f)*4;
+		}else if(oreg[p]==0x16){
+			/* OEM Sega 6-player multitap: use socket 1 as PAD1. */
+			if(oreg[p+2]==0x02){
+				bits = (oreg[p+4]<<8) | oreg[p+6];
+				bits ^= 0xFFFF;
+			}
+			p += 18;
 		}else{
 			p += 2;
 		}


### PR DESCRIPTION
## Summary

Adds SAROO menu input support for the official Sega Saturn 6-player multitap.

With stock SAROO, a controller connected directly to Saturn controller port 1 works in the menu, but a controller connected through the official Sega multitap is ignored by the SAROO UI.

This change allows multitap socket 1 to act as SAROO menu PAD1.

## Investigation

SAROO's existing `pad_read()` handles a directly connected controller response beginning with:

```text
F1 ...
```

The official Japanese Sega 6-player multitap tested here instead reports:

```text
16 02 ...
```

Using a diagnostic firmware on real Saturn hardware, I observed:

Idle:

```text
16 02 FF FF ...
```

A held:

```text
16 02 FB FF ...
```

Using SAROO's existing active-low controller decoding, this produces:

```text
PAD=0400
```

which matches:

```c
#define PAD_A (1<<10)
```

This confirmed that the Saturn/SAROO hardware was receiving the controller state through the tested Japanese OEM multitap and that the first controller could be translated into SAROO's existing PAD input format.

## Fix

When controller port 1 reports `0x16`, SAROO now reads the first controller connected to the multitap as menu PAD1.

The additional multitap controllers are not used for SAROO menu navigation.

Once a Saturn game launches, normal game-side multitap handling is unchanged.

## Testing

Tested on real Sega Saturn hardware using an **official Japanese Sega 6-player multitap**.

**This is the only multitap model/region that has been tested with this patch so far.**

The Japanese OEM multitap was tested with:

- 1 controller connected
- 2 controllers connected
- 3 controllers connected
- 4 controllers connected

Test configurations included standard Saturn controllers and Hori arcade sticks.

Results with the tested Japanese OEM multitap:

- Multitap socket 1 successfully navigates the SAROO menu.
- Games can be selected and launched normally.
- Multiplayer games successfully recognize the additional controllers through the multitap.
- Direct controller operation without the multitap continues to work normally.

## Scope / Limitations

This patch has currently been tested **only with an official Japanese Sega 6-player multitap**.

North American and European Sega multitaps have **not** been tested. Third-party multitaps have also **not** been tested. They may use the same peripheral protocol and may work with this patch, but compatibility with those devices should not be considered confirmed.

The patch intentionally uses only multitap socket 1 for SAROO menu navigation. Controllers in multitap sockets 2-6 are not used for SAROO menu control and remain available to the launched Saturn software.

The `p += 18` handling used by this patch should **not** be considered a fully general Saturn multitap parser. It has only been validated against the tested Japanese OEM Sega multitap and the 1-4 controller configurations described above.

In particular, this patch does not establish that:

- All regional versions of the official Sega multitap produce an identical data layout.
- All possible controller/peripheral combinations produce the same layout.
- Third-party multitaps use the same protocol or packet structure.
- `p += 18` is appropriate for every possible Saturn multitap configuration.

The goal of this patch is narrowly defined: allow controller input from socket 1 of the tested **official Japanese Sega 6-player multitap** to control the SAROO menu, while preserving normal direct-controller behavior and game-side multiplayer operation.

Additional hardware testing or more generalized peripheral parsing may be appropriate before considering this implementation universally compatible with Sega Saturn multitaps.