### PR TITLE
Add OEM Sega 6-player multitap menu support

### DIFF
--- a/Firm_Saturn/language.c
+++ b/Firm_Saturn/language.c
@@ -401,7 +401,7 @@ char *TT(char *str)
 		return str;
 
 	u32 hash = str_hash(str);
-	STR_ENTRY *entry = lang_str_table[hash&0xff];
+	STR_ENTRY *entry = lang_str_table[hash&0x3f];
 	while(entry){
 		if(hash==entry->hash){
 			//printk("TT: %s(%08x) -> %d %s\n", str, hash, entry->index, lang_cur[entry->index]);
@@ -428,7 +428,7 @@ void lang_init(void)
 		lang_str[i].hash = str_hash(lang_zhcn[i]);
 		lang_str[i].index = i;
 
-		int t = (lang_str[i].hash)&0xff;
+		int t = (lang_str[i].hash)&0x3f;
 		if(lang_str_table[t]){
 			lang_str[i].next = lang_str_table[t];
 		}

--- a/Firm_Saturn/main.c
+++ b/Firm_Saturn/main.c
@@ -93,6 +93,13 @@ int pad_read(void)
 			bits = (oreg[p+4]<<8) | (oreg[p+6]);
 			bits ^= 0xFFFF;
 			p += (oreg[p+2]&0x0f)*4;
+		}else if(oreg[p]==0x16){
+			/* OEM Sega 6-player multitap: use socket 1 as PAD1. */
+			if(oreg[p+2]==0x02){
+				bits = (oreg[p+4]<<8) | oreg[p+6];
+				bits ^= 0xFFFF;
+			}
+			p += 18;
 		}else{
 			p += 2;
 		}


### PR DESCRIPTION
## Summary

Adds SAROO menu input support for the official Japanese Sega Saturn 6-player multitap.

This PR also corrects an existing out-of-bounds index in the language translation hash table. That correction became necessary during hardware testing because the multitap modification changed the firmware layout enough to make the existing unsafe access reproducibly freeze the main menu when changing languages with L.

## Multitap support

Stock SAROO accepts a directly connected controller through controller port 1, but the official Japanese Sega 6-player multitap reports a different peripheral response.

Diagnostic testing on real Sega Saturn hardware observed:

Idle:

```text
16 02 FF FF ...
```

A held:

```text
16 02 FB FF ...
```

Using SAROO's existing active-low controller decoding, this produces:

```text
PAD=0400
```

which matches:

```c
#define PAD_A (1<<10)
```

The patch recognizes the `0x16` multitap response and uses the controller in multitap socket 1 as SAROO menu PAD1.

Controllers in sockets 2-6 are not merged into SAROO menu input. Once a game launches, normal game-side multitap handling remains unchanged.

## Language hash-table correction

SAROO declares:

```c
static STR_ENTRY *lang_str_table[64];
```

but indexes the table using:

```c
hash & 0xff
```

and:

```c
(lang_str[i].hash) & 0xff
```

A 64-entry table has valid indices 0-63, while `& 0xff` can produce values from 0-255.

The correction changes both masks to:

```c
& 0x3f
```

which constrains access to the valid 0-63 range.

### Why this change is included here

The official prebuilt SAROO v0.9 firmware was tested and L-button language switching worked normally.

A locally compiled pristine v0.9 build also worked normally.

However:

- Locally compiled pristine v0.9: L language switching works.
- v0.9 + multitap patch only: L language switching reproducibly freezes the menu.
- v0.9 + multitap patch + `0x3f` hash-table correction: L language switching works normally.

This suggests the existing out-of-bounds access is layout-sensitive. It happens not to cause an observable failure in the tested stock build, but becomes harmful after the unrelated code addition changes the firmware layout.

## Hardware testing

Tested on real Sega Saturn hardware using an **official Japanese Sega 6-player multitap**.

Confirmed working with:

- Controller connected directly to Saturn port 1
- L-button language switching
- Multitap socket 1 controlling the SAROO menu
- 1 controller connected to the multitap
- 2 controllers connected
- 3 controllers connected
- 4 controllers connected
- Standard Saturn controllers
- Hori arcade sticks
- Game launching
- Multiplayer operation after launching a game

## Scope / limitations

Multitap testing has currently been performed **only with an official Japanese Sega 6-player multitap**.

North American and European Sega multitaps have not been tested. Third-party multitaps have not been tested.

The current multitap implementation also contains:

```c
p += 18;
```

This should not be considered a fully general Saturn multitap parser. It has been validated with the Japanese OEM multitap and the 1-4 controller configurations available during testing.

The goal of the current implementation is specifically to allow socket 1 of the tested OEM multitap to control the SAROO menu while leaving game-side multiplayer behavior unchanged.