### PR TITLE
Add OEM Sega 6-player multitap menu support

### DIFF
--- a/Firm_Saturn/language.c
+++ b/Firm_Saturn/language.c
@@ -401,7 +401,7 @@ char *TT(char *str)
 		return str;
 
 	u32 hash = str_hash(str);
-	STR_ENTRY *entry = lang_str_table[hash&0xff];
+	STR_ENTRY *entry = lang_str_table[hash&0x3f];
 	while(entry){
 		if(hash==entry->hash){
 			//printk("TT: %s(%08x) -> %d %s\n", str, hash, entry->index, lang_cur[entry->index]);
@@ -428,7 +428,7 @@ void lang_init(void)
 		lang_str[i].hash = str_hash(lang_zhcn[i]);
 		lang_str[i].index = i;
 
-		int t = (lang_str[i].hash)&0xff;
+		int t = (lang_str[i].hash)&0x3f;
 		if(lang_str_table[t]){
 			lang_str[i].next = lang_str_table[t];
 		}

--- a/Firm_Saturn/main.c
+++ b/Firm_Saturn/main.c
@@ -93,6 +93,13 @@ int pad_read(void)
 			bits = (oreg[p+4]<<8) | (oreg[p+6]);
 			bits ^= 0xFFFF;
 			p += (oreg[p+2]&0x0f)*4;
+		}else if(oreg[p]==0x16){
+			/* OEM Sega 6-player multitap: use socket 1 as PAD1. */
+			if(oreg[p+2]==0x02){
+				bits = (oreg[p+4]<<8) | oreg[p+6];
+				bits ^= 0xFFFF;
+			}
+			p += 18;
 		}else{
 			p += 2;
 		}


### PR DESCRIPTION
# Add OEM Sega 6-player multitap support to SAROO menu

This adds support for the official Sega 6-player multitap in SAROO's menu input handling.

## Problem

When an OEM Sega 6-player multitap is connected to controller port 1, controllers connected through the multitap work normally with Saturn software, but the SAROO menu does not respond to controller input.

A controller connected directly to the Saturn works normally in the SAROO menu.

## Multitap fix

`pad_read()` now recognizes the `0x16` peripheral response used by the OEM Sega 6-player multitap and reads the controller connected to socket 1 as PAD1 for menu navigation.

## Language hash-table fix

During hardware testing, the multitap-only build exposed an existing out-of-bounds access in SAROO's language translation hash table when pressing L to change languages.

SAROO declares a 64-entry table:

```c
static STR_ENTRY *lang_str_table[64];
```

but indexed it with `hash & 0xff`, which can produce values from 0-255.

The fix changes both relevant masks to:

```c
& 0x3f
```

which constrains access to the valid 0-63 range.

This fix is included here because testing showed:

* Locally compiled pristine v0.9: L language switching works
* v0.9 + multitap patch only: pressing L reproducibly freezes the SAROO menu
* v0.9 + multitap patch + `0x3f` hash-table fix: L language switching works normally

The out-of-bounds bug appears to be layout-sensitive. The stock build did not show the failure during testing, but the small multitap code addition changed the firmware layout enough to make the issue reproducible.

## Tested hardware

* Official Japanese Sega Saturn 6-player multitap
* Controller connected to multitap socket 1
* SAROO v0.9 / FPGA 06

## Tested behavior

* SAROO menu navigation through the multitap: working
* Controller connected directly to Saturn: working
* L-button language switching: working with both fixes applied
* Games launched from SAROO: working
* Physical Saturn disc booting: working

This has currently only been verified with the official Japanese Sega 6-player multitap. Additional testing with other Saturn multitaps would be welcome.

The current multitap implementation uses:

```c
p += 18;
```

so it should not be considered a fully general Saturn multitap parser.

The goal of this change is specifically to allow socket 1 of the tested OEM multitap to control the SAROO menu while leaving game-side multiplayer handling unchanged.

Related: #366
